### PR TITLE
Break up CI/CD steps to version check > lint > publish > release

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -7,7 +7,47 @@ on:
     branches: [ main ]
 
 jobs:
+  version-check:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.8'
+          
+      - name: Install uv
+        run: |
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          
+      - name: Create virtual environment
+        run: uv venv
+          
+      - name: Install dependencies
+        run: |
+          source .venv/bin/activate
+          uv pip install requests packaging tomli
+        
+      - name: Check version on PyPI
+        run: |
+          source .venv/bin/activate
+          VERSION=$(python -c "import tomli; print(tomli.load(open('pyproject.toml', 'rb'))['project']['version'])")
+          echo "Current version: $VERSION"
+          
+          RESPONSE=$(curl -s https://pypi.org/pypi/dbt-heartbeat/json || echo '{"releases": {}}')
+          if echo "$RESPONSE" | python -c "import sys, json; releases = json.load(sys.stdin)['releases']; sys.exit(0 if '$VERSION' in releases else 1)"; then
+            echo "::error::Version $VERSION already exists on PyPI. Please increment the version number."
+            exit 1
+          else
+            echo "Version $VERSION is available for publishing"
+          fi
+
   lint:
+    needs: version-check
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -37,11 +77,13 @@ jobs:
           ruff check .
 
   publish:
-    needs: lint
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
       
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -68,6 +110,29 @@ jobs:
         env:
           UV_PUBLISH_TOKEN: ${{ secrets.UV_PUBLISH_TOKEN }}
 
+  release:
+    needs: publish
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+      
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.8'
+          
+      - name: Install uv
+        run: |
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          
+      - name: Create virtual environment
+        run: uv venv
+          
       - name: Get version from pyproject.toml
         id: get_version
         run: |
@@ -75,15 +140,16 @@ jobs:
           uv add tomli
           VERSION=$(python -c "import tomli; print(tomli.load(open('pyproject.toml', 'rb'))['project']['version'])")
           echo "version=$VERSION" >> $GITHUB_OUTPUT
-          
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1
         with:
           tag_name: v${{ steps.get_version.outputs.version }}
           name: Release v${{ steps.get_version.outputs.version }}
+          generate_release_notes: true
           body: |
-            Release v${{ steps.get_version.outputs.version }}
-            
             Published to PyPI: https://pypi.org/project/dbt-heartbeat/${{ steps.get_version.outputs.version }}/
+          files: |
+            dist/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dbt-heartbeat"
-version = "0.1.7"
+version = "0.1.8"
 description = "A CLI utility to poll dbt Cloud jobs and send macOS notifications"
 readme = "README.md"
 requires-python = ">=3.8"


### PR DESCRIPTION
# Summary
Break up CI/CD steps to version check > lint > publish > release

# Details

### 1. Version Check (`pull_request` only)
- Check to see that the project version in `pyproject.toml` does not already exist on PyPI
- Fails the job if the version already exists


### 2. Lint (`pull_request` only)
- Depends on `version-check`
- Run `ruff check .` to lint the codebase.

### 3. Publish (`push` to `main` only)
- Build and publish the package to PyPI

### 4. Release (`push` to `main` only)
- Depends on `publish`
- Create a GitHub Release after publishing to PyPI.
- Extracts version from `pyproject.toml`
- Create an automated GitHub Release with tag, release notes, and built artifacts.

**Notes:**
- All jobs run on `ubuntu-latest`
- Publishing and release steps require the following secrets
  - `UV_PUBLISH_TOKEN` and `GITHUB_TOKEN`
- Uses [`uv`](https://github.com/astral-sh/uv) for dependency management and publishing
