### PR TITLE
Add pre-commits and streamline CI/CD pipeline

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -7,34 +7,15 @@ on:
     branches: [ main ]
 
 jobs:
-  version-check:
+  ci-version-check:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.8'
-          
-      - name: Install uv
-        run: |
-          curl -LsSf https://astral.sh/uv/install.sh | sh
-          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-          
-      - name: Create virtual environment
-        run: uv venv
-          
-      - name: Install dependencies
-        run: |
-          source .venv/bin/activate
-          uv pip install requests packaging tomli
-        
       - name: Check version on PyPI
         run: |
-          source .venv/bin/activate
-          VERSION=$(python -c "import tomli; print(tomli.load(open('pyproject.toml', 'rb'))['project']['version'])")
+          VERSION=$(grep -m1 'version = ' pyproject.toml | cut -d'"' -f2)
           echo "Current version: $VERSION"
           
           RESPONSE=$(curl -s https://pypi.org/pypi/dbt-heartbeat/json || echo '{"releases": {}}')
@@ -46,38 +27,48 @@ jobs:
           fi
 
   lint:
-    needs: version-check
+    needs: ci-version-check
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.8'
-          
       - name: Install uv
         run: |
           curl -LsSf https://astral.sh/uv/install.sh | sh
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-          
-      - name: Create virtual environment
-        run: uv venv
-          
-      - name: Install dependencies
-        run: |
-          source .venv/bin/activate
-          uv pip install -e ".[dev]"
-          uv pip install ruff
       
       - name: Run ruff
         run: |
-          source .venv/bin/activate
-          ruff check .
+          uv tool install ruff
+          uv run ruff check .
+
+  cd-version-check:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    outputs:
+      version_exists: ${{ steps.check_version.outputs.version_exists }}
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Check version on PyPI
+        id: check_version
+        run: |
+          VERSION=$(grep -m1 'version = ' pyproject.toml | cut -d'"' -f2)
+          echo "Current version: $VERSION"
+          
+          RESPONSE=$(curl -s https://pypi.org/pypi/dbt-heartbeat/json || echo '{"releases": {}}')
+          if echo "$RESPONSE" | python -c "import sys, json; releases = json.load(sys.stdin)['releases']; sys.exit(0 if '$VERSION' in releases else 1)"; then
+            echo "Version $VERSION already exists on PyPI. Skipping publish and release."
+            echo "version_exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "Version $VERSION is available for publishing"
+            echo "version_exists=false" >> $GITHUB_OUTPUT
+          fi
 
   publish:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: cd-version-check
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.cd-version-check.outputs.version_exists == 'false'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -85,34 +76,21 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
       
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.8'
-          
       - name: Install uv
         run: |
           curl -LsSf https://astral.sh/uv/install.sh | sh
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
           
-      - name: Create virtual environment
-        run: uv venv
-          
-      - name: Build package
+      - name: Build and publish
         run: |
-          source .venv/bin/activate
           uv build
-        
-      - name: Publish to PyPI
-        run: |
-          source .venv/bin/activate
           uv publish
         env:
           UV_PUBLISH_TOKEN: ${{ secrets.UV_PUBLISH_TOKEN }}
 
   release:
-    needs: publish
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: [cd-version-check, publish]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.cd-version-check.outputs.version_exists == 'false'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -120,25 +98,10 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
       
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.8'
-          
-      - name: Install uv
-        run: |
-          curl -LsSf https://astral.sh/uv/install.sh | sh
-          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-          
-      - name: Create virtual environment
-        run: uv venv
-          
       - name: Get version from pyproject.toml
         id: get_version
         run: |
-          source .venv/bin/activate
-          uv add tomli
-          VERSION=$(python -c "import tomli; print(tomli.load(open('pyproject.toml', 'rb'))['project']['version'])")
+          VERSION=$(grep -m1 'version = ' pyproject.toml | cut -d'"' -f2)
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Create GitHub Release
@@ -153,3 +116,4 @@ jobs:
             dist/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -27,8 +27,8 @@ jobs:
           fi
 
   lint:
-    needs: ci-version-check
-    if: github.event_name == 'pull_request'
+    #needs: ci-version-check
+    #if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -41,7 +41,7 @@ jobs:
       - name: Run ruff
         run: |
           uv tool install ruff
-          uv run ruff check .
+          ruff check .
 
   cd-version-check:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+default_install_hook_types: [pre-commit]
+default_stages: [pre-commit]
+
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.7.1
+    hooks:
+      - id: ruff
+        args: [ --fix ]
+      - id: ruff-format

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dbt-heartbeat"
-version = "0.1.8"
+version = "0.1.9"
 description = "A CLI utility to poll dbt Cloud jobs and send macOS notifications"
 readme = "README.md"
 requires-python = ">=3.8"
@@ -26,6 +26,7 @@ packages = ["utils"]
 
 [dependency-groups]
 dev = [
+    "pre-commit>=3.5.0",
     "ruff>=0.11.9",
     "setuptools>=75.3.2",
 ]


### PR DESCRIPTION
# Summary
1. Add `ruff` to fix and format Python code as a pre-commit step before CI linting 
2. Revamp CI/CD pipeline

# Details

### Revamp CI/CD Pipeline
1. Removed the use of `uv` and Python setup where necessary
    - Use grep commands to extract `VERSION` from `pyproject.toml` (instead of `tomli` Python library)
    - Install dependencies using `uv tool` which makes creating a venv unnecessary and can call executables directly
2. Separate out CI/CD jobs into distinct roles:
    - ci-version-check
      - Check to make sure version in `pyproject.toml` does not already exist in PyPi  
      - If already exists, errors in CI
    - lint
      - Run `ruff` to check for code issues 
    - cd-version-check
      - Check to make sure version in `pyproject.toml` does not already exist in PyPi  
        - At this point after CI, should be aware of version changes (upgrade vs revert)
        - Therefore, if version already exists in PyPi, will skip Publish and Release (not error) 
    - publish
      - Publish new version of form `vx.x.x` 
    - release
      - Creates automated release in GitHub that ties to PyPi 
      - Generates releasee notes for what has changed 
 3. Created dependency chaining
   - CI linting depends on ci-version-check
   - CD release depends on cd-version-check and publish