### PR TITLE
Add specific paths to CI/CD workflow

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -3,8 +3,14 @@ name: CI/CD
 on:
   push:
     branches: [ main ]
+    paths:
+      - 'src/**'
+      - 'pyproject.toml'
   pull_request:
     branches: [ main ]
+    paths:
+      - 'src/**'
+      - 'pyproject.toml'
 
 jobs:
   ci-version-check:


### PR DESCRIPTION
# Details

Only trigger CI/CD checks if the following are modified:
1. Any file in `src/`
2. `pyproject.toml`