### PR TITLE
Add cache for "uv install" step

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,8 @@
+runs:
+  using: composite
+  steps:
+    - name: Install uv
+      uses: astral-sh/setup-uv@v3
+      with:
+        version: "0.7.6"
+        cache: true

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -33,20 +33,26 @@ jobs:
           fi
 
   lint:
-    if: github.event_name == 'pull_request'
+    # if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      
-      - name: Install uv
-        run: |
-          curl -LsSf https://astral.sh/uv/install.sh | sh
-          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+      - uses: ./.github/actions/setup
       
       - name: Run ruff
         run: |
           uv tool install ruff
           ruff check .
+
+  build:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
+      
+      - name: Test build
+        run: uv build
 
   cd-version-check:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
@@ -55,6 +61,7 @@ jobs:
       version_exists: ${{ steps.check_version.outputs.version_exists }}
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
       
       - name: Check version on PyPI
         id: check_version
@@ -80,11 +87,7 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
-      
-      - name: Install uv
-        run: |
-          curl -LsSf https://astral.sh/uv/install.sh | sh
-          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+      - uses: ./.github/actions/setup
           
       - name: Build and publish
         run: |
@@ -102,6 +105,7 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
+      - uses: ./.github/actions/setup
       
       - name: Get version from pyproject.toml
         id: get_version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,19 +1,18 @@
 [project]
 name = "dbt-heartbeat"
-version = "0.1.13"
+version = "0.1.14"
 description = "A CLI tool to monitor individual dbt Cloud run jobs and receive macOS notifications when they complete."
 readme = "README.md"
 requires-python = ">=3.8"
 authors = [
     {name = "Jairus Martinez", email = "jairusmartinez@gmail.com"}
 ]
-license = {text = "MIT"}
+license = "MIT"
 keywords = ["dbt", "dbt-cloud", "cli", "notifications"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Environment :: Console",
-    "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
+    "Intended Audience :: Developers",1
     "Operating System :: MacOS",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.8",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ keywords = ["dbt", "dbt-cloud", "cli", "notifications"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Environment :: Console",
-    "Intended Audience :: Developers",1
+    "Intended Audience :: Developers",
     "Operating System :: MacOS",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.8",


### PR DESCRIPTION
# Summary
Every time `uv` is installed for each CI/CD step:
1. The code is reused
2. `uv` is fully installed into the environment

Putting the installation in its own action step, being called in the subsequent steps, and being cached will improve the computational performance and efficiency of the CI/CD pipeline.

# Details

1. **Action Modularization**
`uv` installation is modularized into a reusable action located at `.github/actions/setup/action.yml`. This is considered good practice because:
- It promotes code reuse across different jobs in the workflow
- Makes the workflow file cleaner and more maintainable
- Allows for centralized management of the `uv` setup configuration
- Makes it easier to update the `uv` version or configuration in one place

2. **Cache Configuration**
In the setup action, there's a specific configuration for `uv`:
```yaml
- name: Install uv
  uses: astral-sh/setup-uv@v3
  with:
    version: "0.7.6"
    cache: true
```

The `cache: true` parameter:
- Enables uv's built-in caching mechanism for Python packages
- Significantly speeds up subsequent workflow runs by caching dependencies
- Reduces the time needed to install packages in future runs
- Helps avoid hitting rate limits on package repositories
- Reduces network usage and build times

The caching is especially beneficial in this workflow because:
1. The workflow has multiple jobs (lint, build, publish, etc.) that all need uv
2. Each job runs in a fresh environment, but can benefit from the cached dependencies
3. The workflow runs on both pull requests and pushes to main, so the cache helps speed up frequent PR checks
