### PR TITLE
Add slack notifications

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -41,8 +41,7 @@ jobs:
       
       - name: Run ruff
         run: |
-          uv tool install ruff
-          ruff check .
+          uvx ruff check .
 
   unit-tests:
     if: github.event_name == 'pull_request'

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dbt-heartbeat
 
-A CLI tool to monitor individual dbt Cloud run jobs and receive OS notifications when they complete.
+A CLI tool to monitor individual dbt Cloud run jobs and receive OS/Slack notifications when they complete.
 
 ## Why This Exists
 
@@ -14,11 +14,9 @@ All you need is a dbt Cloud developer PAT, dbt Cloud account ID, and a specific 
 ## Features
 
 - Poll dbt Cloud job runs and monitor their status
-- Cute terminal output with color-coded status updates xD
-- System notifications for job completion (alerts sent to Mac/Windows OS notifications)
-- Configurable polling interval
+- Terminal output with color-coded status updates
 - Can control the log level of the CLI output
-- Detailed job run status information once complete in CLI + system notifications
+- Detailed job run status information once complete in the CLI + System/Slack notifications
 
 ## Prerequisites
 
@@ -72,7 +70,7 @@ To receive Slack notifications, you'll need to create your own Slack App and con
    - Click "Add New Webhook to Workspace"
    - Choose a specific channel (or a DM with yourslef) where notifications should appear
    - Copy the Webhook URL provided
-6. Set up the environment variable in your terminal session or shell configuration file:
+6. Set up a `SLACK_WEBHOOK_URL` environment variable in your terminal session or shell configuration file:
    ```bash
    SLACK_WEBHOOK_URL="https://hooks.slack.com/services/YOUR/WEBHOOK/URL"
    ```
@@ -119,12 +117,16 @@ __Note:__ You can find the `<job_run_id>` in the dbt Cloud UI:
 - `--log-level`: Set the logging level (default: INFO)
   - Choices: DEBUG, INFO, WARNING, ERROR, CRITICAL
 - `--poll-interval`: Time in seconds between polls (default: 30)
+- `--slack`: Send notifications to Slack (requires SLACK_WEBHOOK_URL environment variable)
 
 ### Example
 
 ```bash
-# Poll run job with default settings
+# Poll run job with default settings (system OS notifications)
 dh 123456
+
+# Poll run job with default settings and send message to slack
+dh 123456 --slack
 
 # Poll run job with debug logging and 15-second interval
 dh 123456 --log-level DEBUG --poll-interval 15

--- a/README.md
+++ b/README.md
@@ -59,6 +59,26 @@ The following environment variables are required and must be properly set:
 
 The tool will validate these variables before starting and will notify you if any are missing or invalid.
 
+### Setting up Slack Notifications
+
+To receive Slack notifications, you'll need to create your own Slack App and configure an Incoming Webhook URL. Here's the process:
+
+1. Go to [api.slack.com/apps](https://api.slack.com/apps)
+2. Click "Create New App"
+3. Choose "From scratch"
+4. Name the app (e.g., "dbt-heartbeat") and select the workspace
+5. Under "Features" → "Incoming Webhooks":
+   - Turn on "Activate Incoming Webhooks"
+   - Click "Add New Webhook to Workspace"
+   - Choose a specific channel (or a DM with yourslef) where notifications should appear
+   - Copy the Webhook URL provided
+6. Set up the environment variable in your terminal session or shell configuration file:
+   ```bash
+   SLACK_WEBHOOK_URL="https://hooks.slack.com/services/YOUR/WEBHOOK/URL"
+   ```
+
+Once configured, you can use the `--slack` flag when running `dh` to send notifications to your specified Slack channel and/or DMs.
+
 #### For global export
 If you want to persist the environment variables in all terminal sessions without having to utilize a `.env` file or manually exporting the variables in your terminal session, you can add the export commands to your shell configuration file. (persisted)
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dbt-heartbeat"
-version = "0.2.1"
+version = "0.2.2"
 description = "A CLI tool to monitor individual dbt Cloud run jobs and receive OS notifications when they complete."
 requires-python = ">=3.8"
 authors = [

--- a/src/dbt_heartbeat/main.py
+++ b/src/dbt_heartbeat/main.py
@@ -3,7 +3,7 @@ import logging
 import argparse
 
 from utils.api import DbtCloudApi, JobMonitor
-from utils.notifications import send_system_notification
+from utils.notifications import send_system_notification, send_slack_notification
 from utils.config import validate_environment_vars, load_env_vars
 from utils.display import print_job_status, print_missing_env_vars
 from utils.version import check_version, get_current_version
@@ -80,6 +80,11 @@ def main():
         help="Time in seconds between polls (default: 30)",
     )
     parser.add_argument(
+        "--slack",
+        action="store_true",
+        help="Send notifications to Slack (requires SLACK_WEBHOOK_URL environment variable)",
+    )
+    parser.add_argument(
         "--version",
         action="version",
         version=f"%(prog)s {__version__}",
@@ -121,9 +126,13 @@ def main():
     logger.debug(f"Job completed with final status: {status}")
     print_job_status(status)
 
-    # Send system notification with job run info
-    logger.debug("Attempting to send system notification...")
-    send_system_notification(job_run_info)
+    # Send notifications based on flags
+    if args.slack:
+        logger.debug("Attempting to send Slack notification...")
+        send_slack_notification(job_run_info)
+    else:
+        logger.debug("Attempting to send system notification...")
+        send_system_notification(job_run_info)
 
     sys.exit(0)
 

--- a/src/dbt_heartbeat/main.py
+++ b/src/dbt_heartbeat/main.py
@@ -80,6 +80,7 @@ def main():
         help="Time in seconds between polls (default: 30)",
     )
     parser.add_argument(
+        "-s",
         "--slack",
         action="store_true",
         help="Send notifications to Slack (requires SLACK_WEBHOOK_URL environment variable)",

--- a/src/dbt_heartbeat/main.py
+++ b/src/dbt_heartbeat/main.py
@@ -100,6 +100,8 @@ def main():
 
     # Validate environment variables
     required_vars = ["DBT_CLOUD_API_KEY", "DBT_CLOUD_ACCOUNT_ID"]
+    if args.slack:
+        required_vars.append("SLACK_WEBHOOK_URL")
     missing_vars = validate_environment_vars(required_vars)
     if missing_vars:
         logger.error(f"Missing environment variables: {missing_vars}")

--- a/src/utils/notifications/__init__.py
+++ b/src/utils/notifications/__init__.py
@@ -1,3 +1,3 @@
-from .os_notifs import send_system_notification, get_status_emoji
+from .run_notifs import send_system_notification, get_status_emoji, send_slack_notification
 
-__all__ = ["send_system_notification", "get_status_emoji"]
+__all__ = ["send_system_notification", "get_status_emoji", "send_slack_notification"]

--- a/src/utils/notifications/__init__.py
+++ b/src/utils/notifications/__init__.py
@@ -1,3 +1,7 @@
-from .run_notifs import send_system_notification, get_status_emoji, send_slack_notification
+from .run_notifs import (
+    send_system_notification,
+    get_status_emoji,
+    send_slack_notification,
+)
 
 __all__ = ["send_system_notification", "get_status_emoji", "send_slack_notification"]

--- a/tests/_tests_docs.md
+++ b/tests/_tests_docs.md
@@ -13,10 +13,13 @@ __Note:__ To run the unit/integration tests locally, you need to have string val
 - `test_log_level_changes`: Verifies different log level settings
 - `test_main_with_invalid_job_id`: Tests error handling for invalid job IDs
 - `test_main_with_missing_env_vars`: Verifies environment variable validation
+- `test_slack_flag_long`: Tests the `--slack` flag for Slack notifications
+- `test_slack_flag_short`: Tests the `-s` flag for Slack notifications
 
 ### 2. Integration Tests
 
 - `test_end_to_end_flow`: Verifies complete job monitoring workflow
+- `test_end_to_end_flow_with_slack`: Verifies complete workflow with Slack notifications
 - `test_mock_api_integration`: Tests API and JobMonitor interaction
 - `test_empty_api_response`: Tests handling of empty API responses
 - `test_api_error_handling`: Tests API error scenarios
@@ -34,9 +37,15 @@ __Note:__ To run the unit/integration tests locally, you need to have string val
 - `test_windows_notification_success_mock`: Tests Windows success job notifications
 - `test_windows_notification_parameters`: Tests Windows notification parameters (duration, threading)
 
+#### Slack Notifications
+- `test_notification_success_slack_mock`: Tests successful job notifications sent to Slack
+- `test_notification_error_slack_mock`: Tests error job notifications sent to Slack
+- `test_notification_cancelled_slack_mock`: Tests cancelled job notifications sent to Slack
+
 ### 4. Environment Validation Tests
 - `test_partial_environment_variables`: Tests behavior when only one of the required environment variables is set
 - `test_invalid_environment_variables`: Tests handling of invalid environment variables (empty strings, invalid IDs)
+- `test_slack_flag_missing_webhook`: Tests behavior when Slack webhook URL is not set
 
 ## Test Fixtures (`conftest.py`)
 
@@ -94,23 +103,28 @@ The tests use Python's `unittest.mock` to mock external dependencies:
 2. **System Notifications**
    ```python
    # macOS notifications
-   @patch('utils.notifications.os_notifs.Notifier.notify')
+   @patch('utils.notifications.run_notifs.Notifier.notify')
    
    # Windows notifications
-   @patch('utils.notifications.os_notifs.win10toast')
+   @patch('utils.notifications.run_notifs.win10toast')
+
+   # Slack notifications
+   @patch('utils.notifications.run_notifs.requests.post')
+   @patch('utils.notifications.run_notifs.os.getenv')
    ```
 
 3. **Environment Variables**
    ```python
    @patch.dict(os.environ, {
        'DBT_CLOUD_API_KEY': 'test_key',
-       'DBT_CLOUD_ACCOUNT_ID': 'test_account'
+       'DBT_CLOUD_ACCOUNT_ID': 'test_account',
+       'SLACK_WEBHOOK_URL': 'https://hooks.slack.com/services/test/webhook/url'
    })
    ```
 
 4. **Platform Detection**
    ```python
-   @patch('utils.notifications.os_notifs.sys')
+   @patch('utils.notifications.run_notifs.sys')
    ```
 
 ## Running Tests

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -1,3 +1,6 @@
+from unittest.mock import patch
+import pytest
+from dbt_heartbeat.main import main
 from utils.config import validate_environment_vars
 
 
@@ -24,3 +27,40 @@ def test_invalid_environment_variables(monkeypatch):
         ["DBT_CLOUD_API_KEY", "DBT_CLOUD_ACCOUNT_ID"]
     )
     assert "DBT_CLOUD_API_KEY" in missing_vars
+
+
+@patch("dbt_heartbeat.main.job_monitor")
+@patch("dbt_heartbeat.main.dbt_api")
+@patch("utils.notifications.run_notifs.requests.post")
+@patch("utils.notifications.run_notifs.os.getenv")
+@patch("dbt_heartbeat.main.validate_environment_vars")
+def test_slack_flag_missing_webhook_environment_var(
+    mock_validate_env_vars,
+    mock_getenv,
+    mock_slack_post,
+    mock_dbt_api,
+    mock_job_monitor,
+    sample_job_run_data,
+    mock_job_run_info,
+    mock_sys_argv,
+    caplog,
+):
+    """Test that appropriate error is logged when Slack webhook URL is missing."""
+    # Setup mocks
+    mock_job_monitor.monitor_job.return_value = sample_job_run_data
+    mock_dbt_api.get_job_run_info.return_value = mock_job_run_info
+    mock_getenv.return_value = None  # Simulate missing webhook URL
+    mock_validate_env_vars.return_value = []  # No missing required env vars
+
+    with mock_sys_argv("12345", "--slack"):
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+        assert exc_info.value.code == 0
+
+    # Verify error was logged
+    assert any(
+        "SLACK_WEBHOOK_URL environment variable not set" in record.message
+        for record in caplog.records
+    )
+    # Verify no Slack notification was sent
+    mock_slack_post.assert_not_called()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -16,7 +16,7 @@ def test_end_to_end_flow(capsys):
     with patch("dbt_heartbeat.main.job_monitor") as mock_monitor, patch(
         "dbt_heartbeat.main.dbt_api"
     ) as mock_api, patch(
-        "utils.notifications.os_notifs.Notifier.notify"
+        "utils.notifications.run_notifs.Notifier.notify"
     ) as mock_notify:
         # Setup mock responses
         mock_monitor.monitor_job.return_value = {

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -62,6 +62,74 @@ def test_end_to_end_flow(capsys):
         mock_notify.assert_called_once()
 
 
+@skip_if_not_macos
+def test_end_to_end_flow_with_slack(capsys):
+    """Test the entire flow from command-line input to job completion with Slack notification."""
+    with patch("dbt_heartbeat.main.job_monitor") as mock_monitor, patch(
+        "dbt_heartbeat.main.dbt_api"
+    ) as mock_api, patch(
+        "utils.notifications.run_notifs.requests.post"
+    ) as mock_slack_post, patch(
+        "utils.notifications.run_notifs.os.getenv"
+    ) as mock_getenv:
+        # Setup mock responses
+        mock_monitor.monitor_job.return_value = {
+            "name": "Test Integration Job # 1",
+            "status": "Success",
+            "status_humanized": "Success",
+            "duration": "4 minutes, 20 seconds",
+            "duration_humanized": "4 minutes, 20 seconds",
+            "run_duration_humanized": "4 minutes, 20 seconds",
+            "queued_duration_humanized": "0s",
+            "finished_at": "11:11 AM",
+            "is_success": True,
+            "is_error": False,
+            "in_progress": False,
+            "job_id": 12345,
+            "run_id": 67890,
+        }
+        mock_api.get_job_run_info.return_value = {
+            "name": "Test Integration Job # 1",
+            "status": "Success",
+            "status_humanized": "Success",
+            "duration": "4 minutes, 20 seconds",
+            "duration_humanized": "4 minutes, 50 seconds",
+            "run_duration_humanized": "4 minutes, 50 seconds",
+            "queued_duration_humanized": "0s",
+            "finished_at": "11:11 AM",
+            "is_success": True,
+            "is_error": False,
+            "in_progress": False,
+            "job_id": 12345,
+            "run_id": 67890,
+        }
+        mock_getenv.return_value = "https://hooks.slack.com/services/test/webhook/url"
+        mock_slack_response = MagicMock()
+        mock_slack_response.raise_for_status.return_value = None
+        mock_slack_post.return_value = mock_slack_response
+
+        # Run the main function with --slack flag
+        with patch("sys.argv", ["script.py", "12345", "--slack"]):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+            assert exc_info.value.code == 0
+
+        # Verify the flow
+        mock_monitor.monitor_job.assert_called_once_with("12345", 30)
+        mock_api.get_job_run_info.assert_called_once_with("12345")
+        mock_slack_post.assert_called_once()
+
+        # Verify Slack message content
+        call_args = mock_slack_post.call_args
+        assert call_args[0][0] == "https://hooks.slack.com/services/test/webhook/url"
+        blocks = call_args[1]["json"]["blocks"]
+        assert blocks[0]["text"]["text"] == "✅ dbt Job Status Update"
+        assert any(
+            "Test Integration Job # 1" in field["text"] for field in blocks[1]["fields"]
+        )
+        assert any("Success" in field["text"] for field in blocks[1]["fields"])
+
+
 def test_mock_api_integration():
     """Test the interaction between DbtCloudApi and JobMonitor with a fully mocked API."""
     mock_api = MagicMock(spec=DbtCloudApi)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -25,7 +25,7 @@ def test_main_without_job_id(capsys, mock_sys_argv):
 
 @patch("dbt_heartbeat.main.job_monitor")
 @patch("dbt_heartbeat.main.dbt_api")
-@patch("utils.notifications.os_notifs.Notifier")
+@patch("utils.notifications.run_notifs.Notifier")
 def test_main_with_valid_job_id(
     mock_notifier,
     mock_dbt_api,
@@ -62,7 +62,7 @@ def test_main_with_missing_env_vars(mock_validate_env_vars, mock_sys_argv):
 
 @patch("dbt_heartbeat.main.job_monitor")
 @patch("dbt_heartbeat.main.dbt_api")
-@patch("utils.notifications.os_notifs.Notifier")
+@patch("utils.notifications.run_notifs.Notifier")
 def test_custom_poll_interval(
     mock_notifier,
     mock_dbt_api,
@@ -87,7 +87,7 @@ def test_custom_poll_interval(
 
 @patch("dbt_heartbeat.main.job_monitor")
 @patch("dbt_heartbeat.main.dbt_api")
-@patch("utils.notifications.os_notifs.Notifier")
+@patch("utils.notifications.run_notifs.Notifier")
 def test_log_level_changes(
     mock_dbt_api,
     mock_job_monitor,

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,5 +1,5 @@
 import pytest
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 from dbt_heartbeat.main import main
 
 
@@ -121,3 +121,77 @@ def test_log_level_changes(
 
     # Verify debug messages are not logged
     assert not any(record.levelname == "DEBUG" for record in caplog.records)
+
+
+@patch("dbt_heartbeat.main.job_monitor")
+@patch("dbt_heartbeat.main.dbt_api")
+@patch("utils.notifications.run_notifs.requests.post")
+@patch("utils.notifications.run_notifs.os.getenv")
+def test_slack_flag_long(
+    mock_getenv,
+    mock_slack_post,
+    mock_dbt_api,
+    mock_job_monitor,
+    sample_job_run_data,
+    mock_job_run_info,
+    mock_sys_argv,
+):
+    """Test that the --slack flag triggers Slack notifications."""
+    # Setup mocks
+    mock_job_monitor.monitor_job.return_value = sample_job_run_data
+    mock_dbt_api.get_job_run_info.return_value = mock_job_run_info
+    mock_getenv.return_value = "https://hooks.slack.com/services/test/webhook/url"
+    mock_slack_response = MagicMock()
+    mock_slack_response.raise_for_status.return_value = None
+    mock_slack_post.return_value = mock_slack_response
+
+    with mock_sys_argv("12345", "--slack"):
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+        assert exc_info.value.code == 0
+
+    # Verify Slack notification was sent
+    mock_slack_post.assert_called_once()
+    call_args = mock_slack_post.call_args
+    assert call_args[0][0] == "https://hooks.slack.com/services/test/webhook/url"
+    blocks = call_args[1]["json"]["blocks"]
+    assert blocks[0]["text"]["text"] == "✅ dbt Job Status Update"
+    assert any("Test Job" in field["text"] for field in blocks[1]["fields"])
+    assert any("Success" in field["text"] for field in blocks[1]["fields"])
+
+
+@patch("dbt_heartbeat.main.job_monitor")
+@patch("dbt_heartbeat.main.dbt_api")
+@patch("utils.notifications.run_notifs.requests.post")
+@patch("utils.notifications.run_notifs.os.getenv")
+def test_slack_flag_short(
+    mock_getenv,
+    mock_slack_post,
+    mock_dbt_api,
+    mock_job_monitor,
+    sample_job_run_data,
+    mock_job_run_info,
+    mock_sys_argv,
+):
+    """Test that the -s flag triggers Slack notifications."""
+    # Setup mocks
+    mock_job_monitor.monitor_job.return_value = sample_job_run_data
+    mock_dbt_api.get_job_run_info.return_value = mock_job_run_info
+    mock_getenv.return_value = "https://hooks.slack.com/services/test/webhook/url"
+    mock_slack_response = MagicMock()
+    mock_slack_response.raise_for_status.return_value = None
+    mock_slack_post.return_value = mock_slack_response
+
+    with mock_sys_argv("12345", "-s"):
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+        assert exc_info.value.code == 0
+
+    # Verify Slack notification was sent
+    mock_slack_post.assert_called_once()
+    call_args = mock_slack_post.call_args
+    assert call_args[0][0] == "https://hooks.slack.com/services/test/webhook/url"
+    blocks = call_args[1]["json"]["blocks"]
+    assert blocks[0]["text"]["text"] == "✅ dbt Job Status Update"
+    assert any("Test Job" in field["text"] for field in blocks[1]["fields"])
+    assert any("Success" in field["text"] for field in blocks[1]["fields"])

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -1,5 +1,5 @@
 from unittest.mock import patch, MagicMock
-from utils.notifications import send_system_notification
+from utils.notifications import send_system_notification, send_slack_notification
 from tests.conftest import assert_notification_content
 
 
@@ -140,3 +140,105 @@ def test_windows_notification_parameters(
         # Assert the notification parameters
         assert call_kwargs["duration"] == 10
         assert call_kwargs["threaded"] is True
+
+
+@patch("utils.notifications.run_notifs.requests.post")
+@patch("utils.notifications.run_notifs.os.getenv")
+def test_notification_success_slack_mock(
+    mock_getenv, mock_post, sample_job_run_data, job_states
+):
+    """Test that Slack notifications are sent correctly when a job succeeds."""
+    # Setup the mocks
+    mock_getenv.return_value = "https://hooks.slack.com/services/test/webhook/url"
+    mock_response = MagicMock()
+    mock_response.raise_for_status.return_value = None
+    mock_post.return_value = mock_response
+
+    job_data = {**sample_job_run_data, **job_states["success"]}
+    send_slack_notification(job_data)
+
+    # Verify the webhook was called
+    mock_post.assert_called_once()
+
+    # Get the JSON payload that was sent
+    call_args = mock_post.call_args
+    assert call_args[0][0] == "https://hooks.slack.com/services/test/webhook/url"
+
+    blocks = call_args[1]["json"]["blocks"]
+
+    # Verify the blocks structure
+    assert blocks[0]["text"]["text"] == "✅ dbt Job Status Update"
+    assert any("Test Job" in field["text"] for field in blocks[1]["fields"])
+    assert any("Success" in field["text"] for field in blocks[1]["fields"])
+
+
+@patch("utils.notifications.run_notifs.requests.post")
+@patch("utils.notifications.run_notifs.os.getenv")
+def test_notification_error_slack_mock(
+    mock_getenv, mock_post, sample_job_run_data, job_states
+):
+    """Test that Slack notifications are sent correctly when a job fails."""
+    # Setup the mocks
+    mock_getenv.return_value = "https://hooks.slack.com/services/test/webhook/url"
+    mock_response = MagicMock()
+    mock_response.raise_for_status.return_value = None
+    mock_post.return_value = mock_response
+
+    job_data = {**sample_job_run_data, **job_states["error"]}
+    send_slack_notification(job_data)
+
+    # Verify the webhook was called
+    mock_post.assert_called_once()
+
+    # Get the JSON payload that was sent
+    call_args = mock_post.call_args
+    assert call_args[0][0] == "https://hooks.slack.com/services/test/webhook/url"
+
+    blocks = call_args[1]["json"]["blocks"]
+
+    # Verify the blocks structure
+    assert blocks[0]["text"]["text"] == "❌ dbt Job Status Update"
+    assert any("Test Job" in field["text"] for field in blocks[1]["fields"])
+    assert any("Error" in field["text"] for field in blocks[1]["fields"])
+    # Find the error message block and verify its content
+    error_block = next(
+        (
+            block
+            for block in blocks
+            if block.get("type") == "section"
+            and "Error:" in block.get("text", {}).get("text", "")
+        ),
+        None,
+    )
+    assert error_block is not None
+    assert "Test error" in error_block["text"]["text"]
+
+
+@patch("utils.notifications.run_notifs.requests.post")
+@patch("utils.notifications.run_notifs.os.getenv")
+def test_notification_cancelled_slack_mock(
+    mock_getenv, mock_post, sample_job_run_data, job_states
+):
+    """Test that Slack notifications are sent correctly when a job is cancelled."""
+    # Setup the mocks
+    mock_getenv.return_value = "https://hooks.slack.com/services/test/webhook/url"
+    mock_response = MagicMock()
+    mock_response.raise_for_status.return_value = None
+    mock_post.return_value = mock_response
+
+    job_data = {**sample_job_run_data, **job_states["cancelled"]}
+    send_slack_notification(job_data)
+
+    # Verify the webhook was called
+    mock_post.assert_called_once()
+
+    # Get the JSON payload that was sent
+    call_args = mock_post.call_args
+    assert call_args[0][0] == "https://hooks.slack.com/services/test/webhook/url"
+
+    blocks = call_args[1]["json"]["blocks"]
+
+    # Verify the blocks structure
+    assert blocks[0]["text"]["text"] == "⚠️ dbt Job Status Update"
+    assert any("Test Job" in field["text"] for field in blocks[1]["fields"])
+    assert any("Cancelled" in field["text"] for field in blocks[1]["fields"])

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -3,8 +3,8 @@ from utils.notifications import send_system_notification
 from tests.conftest import assert_notification_content
 
 
-@patch("utils.notifications.os_notifs.sys")
-@patch("utils.notifications.os_notifs.Notifier")
+@patch("utils.notifications.run_notifs.sys")
+@patch("utils.notifications.run_notifs.Notifier")
 def test_notification_cancelled_mock(
     mock_notifier, mock_sys, sample_job_run_data, job_states
 ):
@@ -19,8 +19,8 @@ def test_notification_cancelled_mock(
     assert_notification_content(message, "Test Job", "Cancelled")
 
 
-@patch("utils.notifications.os_notifs.sys")
-@patch("utils.notifications.os_notifs.Notifier")
+@patch("utils.notifications.run_notifs.sys")
+@patch("utils.notifications.run_notifs.Notifier")
 def test_notification_error_mock(
     mock_notifier, mock_sys, sample_job_run_data, job_states
 ):
@@ -35,8 +35,8 @@ def test_notification_error_mock(
     assert_notification_content(message, "Test Job", "Error", error_msg="Test error")
 
 
-@patch("utils.notifications.os_notifs.sys")
-@patch("utils.notifications.os_notifs.win10toast", create=True)
+@patch("utils.notifications.run_notifs.sys")
+@patch("utils.notifications.run_notifs.win10toast", create=True)
 def test_windows_notification_cancelled_mock(
     mock_win10toast, mock_sys, sample_job_run_data, job_states
 ):
@@ -47,7 +47,7 @@ def test_windows_notification_cancelled_mock(
     mock_win10toast.ToastNotifier.return_value = mock_toaster
 
     # Create the toaster instance in the module
-    with patch("utils.notifications.os_notifs.toaster", mock_toaster, create=True):
+    with patch("utils.notifications.run_notifs.toaster", mock_toaster, create=True):
         job_data = {**sample_job_run_data, **job_states["cancelled"]}
         send_system_notification(job_data)
         mock_toaster.show_toast.assert_called_once()
@@ -62,8 +62,8 @@ def test_windows_notification_cancelled_mock(
         assert_notification_content(message, "Test Job", "Cancelled")
 
 
-@patch("utils.notifications.os_notifs.sys")
-@patch("utils.notifications.os_notifs.win10toast", create=True)
+@patch("utils.notifications.run_notifs.sys")
+@patch("utils.notifications.run_notifs.win10toast", create=True)
 def test_windows_notification_error_mock(
     mock_win10toast, mock_sys, sample_job_run_data, job_states
 ):
@@ -74,7 +74,7 @@ def test_windows_notification_error_mock(
     mock_win10toast.ToastNotifier.return_value = mock_toaster
 
     # Create the toaster instance in the module
-    with patch("utils.notifications.os_notifs.toaster", mock_toaster, create=True):
+    with patch("utils.notifications.run_notifs.toaster", mock_toaster, create=True):
         job_data = {**sample_job_run_data, **job_states["error"]}
         send_system_notification(job_data)
         mock_toaster.show_toast.assert_called_once()
@@ -91,8 +91,8 @@ def test_windows_notification_error_mock(
         )
 
 
-@patch("utils.notifications.os_notifs.sys")
-@patch("utils.notifications.os_notifs.win10toast", create=True)
+@patch("utils.notifications.run_notifs.sys")
+@patch("utils.notifications.run_notifs.win10toast", create=True)
 def test_windows_notification_success_mock(
     mock_win10toast, mock_sys, sample_job_run_data, job_states
 ):
@@ -103,7 +103,7 @@ def test_windows_notification_success_mock(
     mock_win10toast.ToastNotifier.return_value = mock_toaster
 
     # Create the toaster instance in the module
-    with patch("utils.notifications.os_notifs.toaster", mock_toaster, create=True):
+    with patch("utils.notifications.run_notifs.toaster", mock_toaster, create=True):
         job_data = {**sample_job_run_data, **job_states["success"]}
         send_system_notification(job_data)
         mock_toaster.show_toast.assert_called_once()
@@ -118,8 +118,8 @@ def test_windows_notification_success_mock(
         assert_notification_content(message, "Test Job", "Success")
 
 
-@patch("utils.notifications.os_notifs.sys")
-@patch("utils.notifications.os_notifs.win10toast", create=True)
+@patch("utils.notifications.run_notifs.sys")
+@patch("utils.notifications.run_notifs.win10toast", create=True)
 def test_windows_notification_parameters(
     mock_win10toast, mock_sys, sample_job_run_data, job_states
 ):
@@ -130,7 +130,7 @@ def test_windows_notification_parameters(
     mock_win10toast.ToastNotifier.return_value = mock_toaster
 
     # Create the toaster instance in the module
-    with patch("utils.notifications.os_notifs.toaster", mock_toaster, create=True):
+    with patch("utils.notifications.run_notifs.toaster", mock_toaster, create=True):
         job_data = {**sample_job_run_data, **job_states["success"]}
         send_system_notification(job_data)
 


### PR DESCRIPTION
# Summary
Added Slack notification support- allows users to receive job status updates in their Slack channels or specified DMs. 

File changes include command-line flags (`--slack` or `-s`), environment variable configuration, and test coverage.

# Details

```bash
# Run with default OS notifs
dh 123456

# Run with slack notifs
dh 123456 -s
dh 123456 --slack
```

Sending to my user DMs in Slack:
<img width="1274" alt="Screenshot 2025-06-15 at 4 06 59 PM" src="https://github.com/user-attachments/assets/150dffd0-d197-425f-8589-05c895851cc8" />


## Features Added
- Slack notification support with both long (`--slack`) and short (`-s`) command-line flags
- Environment variable configuration for `SLACK_WEBHOOK_URL`
- Informative (?) Slack message formatting with emojis and structured blocks

## Technical Details
- Uses Slack's Block Kit for message formatting
- Implements proper error handling for missing webhook URLs
- Maintains backward compatibility with existing notification system
- Follows the same pattern as existing notification tests

## Dependencies
No new dependencies added. Uses existing `requests` library for Slack API calls.